### PR TITLE
Timer oncomplate log fix

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -10,7 +10,7 @@ export default function HomeScreen() {
       <SelectPreview />
 
       <PomodoroTimer
-        initialMinutes={25}
+        initialMinutes={0.1}
         onComplete={() => {
           console.log("Pomodoro session completed from HomeScreen!");
         }}

--- a/lib/hooks/useTimer.ts
+++ b/lib/hooks/useTimer.ts
@@ -23,6 +23,7 @@ export const useTimer = ({
 }: UseTimerProps = {}): UseTimerReturn => {
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const backgroundTimeRef = useRef<number | null>(null);
+  const completionCalledRef = useRef<boolean>(false);
   
   const initialTime = initialMinutes * 60; // Convert to seconds
   const [timeRemaining, setTimeRemaining] = useState(initialTime);
@@ -49,7 +50,10 @@ export const useTimer = ({
         if (prev <= 1) {
           setIsRunning(false);
           setIsCompleted(true);
-          onComplete?.();
+          if (!completionCalledRef.current) {
+            completionCalledRef.current = true;
+            onComplete?.();
+          }
           return 0;
         }
         return prev - 1;
@@ -71,6 +75,7 @@ export const useTimer = ({
     setIsRunning(false);
     setIsCompleted(false);
     setTimeRemaining(initialTime);
+    completionCalledRef.current = false;
     if (intervalRef.current) {
       clearInterval(intervalRef.current);
       intervalRef.current = null;
@@ -92,7 +97,10 @@ export const useTimer = ({
           if (newTime <= 0) {
             setIsRunning(false);
             setIsCompleted(true);
-            onComplete?.();
+            if (!completionCalledRef.current) {
+              completionCalledRef.current = true;
+              onComplete?.();
+            }
           }
           return newTime;
         });


### PR DESCRIPTION
This pull request updates the Pomodoro timer functionality, primarily to improve timer completion handling and prevent duplicate completion callbacks. The timer duration is also changed for testing purposes. The most important changes are grouped below:

**Timer completion handling improvements:**

* Added a `completionCalledRef` flag in `useTimer` to ensure the `onComplete` callback is only called once when the timer completes, preventing duplicate calls. [[1]](diffhunk://#diff-efa606ff925a1c634e35fa1131581fd63e2ce5da7a441f115ac80f3db24a6d4eR26) [[2]](diffhunk://#diff-efa606ff925a1c634e35fa1131581fd63e2ce5da7a441f115ac80f3db24a6d4eR53-R56) [[3]](diffhunk://#diff-efa606ff925a1c634e35fa1131581fd63e2ce5da7a441f115ac80f3db24a6d4eR100-R104)
* Reset the `completionCalledRef` flag when the timer is reset, ensuring correct behavior for subsequent timer sessions.

**Testing and configuration:**

* Changed the initial timer duration in `HomeScreen` from 25 minutes to 0.1 minutes (6 seconds) for easier testing of completion logic.