### PR TITLE
Pomodoro Sheet

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,10 +1,10 @@
 {
   "mcpServers": {
     "RadonAi": {
-      "url": "http://127.0.0.1:56813/mcp",
+      "url": "http://127.0.0.1:56963/mcp",
       "type": "http",
       "headers": {
-        "nonce": "4bb6255b-6c9a-4704-bd09-96a29c4c318a"
+        "nonce": "e8c356bd-837f-48d3-b3ff-3c30fa99096f"
       }
     }
   }

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,13 +1,15 @@
 import { AlertDialogPreview } from "@/components/AlertDialogPreview";
 import { PomodoroTimer } from "@/components/PomodoroTimer";
-import { SelectPreview } from "@/components/TestSelect";
+import TaskSheet from "@/components/TaskSheet";
 import React from "react";
 import { View } from "react-native";
 
 export default function HomeScreen() {
   return (
-    <View className="flex-1 items-center justify-center gap-16">
-      <SelectPreview />
+    <View className="flex-1 items-center justify-center gap-8 px-6">
+     
+        <TaskSheet />
+     
 
       <PomodoroTimer
         initialSeconds={25 * 60}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,18 +1,25 @@
 import "react-native-reanimated";
 
-
 import "@/global.css";
 import { NAV_THEME } from "@/lib/theme";
-import { Montserrat_400Regular, Montserrat_500Medium, Montserrat_600SemiBold, Montserrat_700Bold, Montserrat_800ExtraBold, Montserrat_900Black, useFonts } from "@expo-google-fonts/montserrat";
 import {
-  ThemeProvider
-} from "@react-navigation/native";
+  Montserrat_400Regular,
+  Montserrat_500Medium,
+  Montserrat_600SemiBold,
+  Montserrat_700Bold,
+  Montserrat_800ExtraBold,
+  Montserrat_900Black,
+  useFonts,
+} from "@expo-google-fonts/montserrat";
+import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
+import { ThemeProvider } from "@react-navigation/native";
 import { PortalHost } from "@rn-primitives/portal";
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 
 import * as SplashScreen from "expo-splash-screen";
 import React from "react";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
 export const unstable_settings = {
   anchor: "(tabs)",
 };
@@ -37,14 +44,16 @@ export default function RootLayout() {
   }
 
   return (
-    <ThemeProvider value={NAV_THEME["light"]}>
-      
-      <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        
-      </Stack>
-      <PortalHost />
-      <StatusBar style="auto" />
-    </ThemeProvider>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <BottomSheetModalProvider>
+        <ThemeProvider value={NAV_THEME["light"]}>
+          <Stack>
+            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+          </Stack>
+          <PortalHost />
+          <StatusBar style="auto" />
+        </ThemeProvider>
+      </BottomSheetModalProvider>
+    </GestureHandlerRootView>
   );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "dependencies": {
         "@expo-google-fonts/montserrat": "^0.4.2",
         "@expo/vector-icons": "^15.0.2",
+        "@gorhom/bottom-sheet": "^5",
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
@@ -14,6 +15,7 @@
         "@rn-primitives/portal": "^1.3.0",
         "@rn-primitives/select": "^1.2.0",
         "@rn-primitives/slot": "^1.2.0",
+        "@shopify/flash-list": "^2.0.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "expo": "~54.0.2",
@@ -334,6 +336,10 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
 
+    "@gorhom/bottom-sheet": ["@gorhom/bottom-sheet@5.2.6", "", { "dependencies": { "@gorhom/portal": "1.0.14", "invariant": "^2.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-native": "*", "react": "*", "react-native": "*", "react-native-gesture-handler": ">=2.16.1", "react-native-reanimated": ">=3.16.0 || >=4.0.0-" }, "optionalPeers": ["@types/react", "@types/react-native"] }, "sha512-vmruJxdiUGDg+ZYcDmS30XDhq/h/+QkINOI5LY/uGjx8cPGwgJW0H6AB902gNTKtccbiKe/rr94EwdmIEz+LAQ=="],
+
+    "@gorhom/portal": ["@gorhom/portal@1.0.14", "", { "dependencies": { "nanoid": "^3.3.1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-MXyL4xvCjmgaORr/rtryDNFy3kU4qUbKlwtQqqsygd0xX3mhKjOLn6mQK8wfu0RkoE0pBE0nAasRoHua+/QZ7A=="],
+
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
@@ -499,6 +505,8 @@
     "@rn-primitives/types": ["@rn-primitives/types@1.2.0", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-web": "*" }, "optionalPeers": ["react-native", "react-native-web"] }, "sha512-b+6zKgdKVqAfaFPSfhwlQL0dnPQXPpW890m3eguC0VDI1eOsoEvUfVb6lmgH4bum9MmI0xymq4tOUI/fsKLoCQ=="],
 
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
+
+    "@shopify/flash-list": ["@shopify/flash-list@2.0.3", "", { "dependencies": { "tslib": "2.8.1" }, "peerDependencies": { "@babel/runtime": "*", "react": "*", "react-native": "*" } }, "sha512-jUlHuZFoPdqRCDvOqsb2YkTttRPyV8Tb/EjCx3gE2wjr4UTM+fE0Ltv9bwBg0K7yo/SxRNXaW7xu5utusRb0xA=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.27.8", "", {}, "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="],
 

--- a/components/TaskButton.tsx
+++ b/components/TaskButton.tsx
@@ -1,0 +1,64 @@
+import { Text } from "@/components/ui/text";
+import { formatDuration } from "@/lib/utils";
+import React from "react";
+import { TouchableOpacity, View } from "react-native";
+import Icons from "./ui/icons";
+
+interface Session {
+  id: number;
+  step: number;
+  total_seconds: number;
+  type: "work" | "break";
+}
+
+interface TaskButtonProps {
+  title: string;
+  sessions: Session[];
+  borderColor?: string;
+  onPress?: () => void;
+}
+
+export const TaskButton: React.FC<TaskButtonProps> = ({
+  title,
+  sessions,
+  borderColor = "#3B82F6", // default blue color
+  onPress,
+}) => {
+  const renderSessionDurations = () => {
+    return sessions.map((session, index) => (
+      <View key={session.id} className="flex-row items-center">
+        <Text className="text-xs text-gray-600">
+          {formatDuration(session.total_seconds)}
+        </Text>
+        {index < sessions.length - 1 && (
+          <View className="mx-1">
+            <Icons name="ArrowRight" size={12} color="#9CA3AF" />
+          </View>
+        )}
+      </View>
+    ));
+  };
+
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      className="bg-white rounded-3xl p-4 mb-3 border border-zinc-200"
+      style={{
+        borderLeftWidth: 4,
+        borderLeftColor: borderColor,
+      }}
+    >
+      {/* Title Row */}
+      <View className="mb-2">
+        <Text className="text-lg font-sans-medium text-gray-900">{title}</Text>
+      </View>
+      
+      {/* Session Info Row */}
+      <View className="flex-row items-center flex-wrap">
+        {renderSessionDurations()}
+      </View>
+    </TouchableOpacity>
+  );
+};
+
+export default TaskButton;

--- a/components/TaskSheet.tsx
+++ b/components/TaskSheet.tsx
@@ -1,0 +1,100 @@
+import { Text } from "@/components/ui/text";
+import { currentPomodoro } from "@/lib/hooks/usePomodoro";
+import {
+    BottomSheetBackdrop,
+    BottomSheetModal,
+    BottomSheetView
+} from "@gorhom/bottom-sheet";
+import React, { useCallback, useRef } from "react";
+import { TouchableOpacity, View } from "react-native";
+import TaskButton from "./TaskButton";
+import Icons from "./ui/icons";
+
+const TaskSheet = () => {
+  // ref
+  const bottomSheetModalRef = useRef<BottomSheetModal>(null);
+
+  // callbacks
+  const handlePresentModalPress = useCallback(() => {
+    bottomSheetModalRef.current?.present();
+  }, []);
+  const handleSheetChanges = useCallback((index: number) => {
+    console.log("handleSheetChanges", index);
+  }, []);
+
+  // renders
+  return (
+   
+      <View className="w-full max-w-xs px-6">
+        <TouchableOpacity className="flex-row items-center justify-between bg-zinc-100 rounded-md p-2" onPress={handlePresentModalPress}>
+            <Text className="text-sm font-medium">Pomodoro #1</Text>
+            <Icons name="ChevronDown" size={24} color="black" />
+        </TouchableOpacity>
+        <BottomSheetModal
+          ref={bottomSheetModalRef}
+          onChange={handleSheetChanges}
+          enableDynamicSizing={false}
+          snapPoints={["45%", "75%"]}
+          enablePanDownToClose={true}
+          enableDismissOnClose={true}
+          backgroundStyle={{
+            backgroundColor: "#ffffff",
+            borderTopLeftRadius: 20,
+            borderTopRightRadius: 20,
+          }}
+          handleIndicatorStyle={{
+            backgroundColor: "#D1D5DB",
+            width: 50,
+          }}
+         
+          backdropComponent={(props) => (
+            <BottomSheetBackdrop
+              {...props}
+              appearsOnIndex={0}
+              disappearsOnIndex={-1}
+              opacity={0.5}
+            />
+          )}
+        >
+          <BottomSheetView className="flex-1 px-5 pt-2.5">
+            <Text className="text-xl font-bold text-gray-900 mb-4">
+              Select Pomodoro Session
+            </Text>
+            
+            <TaskButton
+              title="Pomodoro #1"
+              sessions={currentPomodoro().sessions}
+              borderColor="#3B82F6"
+              onPress={() => console.log("Selected Pomodoro #1")}
+            />
+            
+            <TaskButton
+              title="Study Session"
+              sessions={[
+                { id: 1, step: 1, total_seconds: 45 * 60, type: "work" },
+                { id: 2, step: 2, total_seconds: 15 * 60, type: "break" },
+                { id: 3, step: 3, total_seconds: 45 * 60, type: "work" },
+                { id: 4, step: 4, total_seconds: 30 * 60, type: "break" },
+              ]}
+              borderColor="#10B981"
+              onPress={() => console.log("Selected Study Session")}
+            />
+            
+            <TaskButton
+              title="Deep Work"
+              sessions={[
+                { id: 5, step: 1, total_seconds: 90 * 60, type: "work" },
+                { id: 6, step: 2, total_seconds: 20 * 60, type: "break" },
+              ]}
+              borderColor="#F59E0B"
+              onPress={() => console.log("Selected Deep Work")}
+            />
+          </BottomSheetView>
+        </BottomSheetModal>
+      </View>
+    
+  );
+};
+
+
+export default TaskSheet;

--- a/lib/hooks/usePomodoro.ts
+++ b/lib/hooks/usePomodoro.ts
@@ -41,3 +41,7 @@ function createPomodoro() {}
 function currentPomodoro() {
   return dummyPomodoro;
 }
+
+export { createPomodoro, currentPomodoro, getPomodoro };
+export type { Pomodoro };
+

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,19 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
  
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
+}
+
+export function formatDuration(seconds: number): string {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  
+  if (hours > 0 && minutes > 0) {
+    return `${hours}sa ${minutes}dk`;
+  } else if (hours > 0) {
+    return `${hours}sa`;
+  } else {
+    return `${minutes}dk`;
+  }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@expo-google-fonts/montserrat": "^0.4.2",
     "@expo/vector-icons": "^15.0.2",
+    "@gorhom/bottom-sheet": "^5",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
@@ -21,6 +22,7 @@
     "@rn-primitives/portal": "^1.3.0",
     "@rn-primitives/select": "^1.2.0",
     "@rn-primitives/slot": "^1.2.0",
+    "@shopify/flash-list": "^2.0.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "expo": "~54.0.2",


### PR DESCRIPTION
This pull request introduces a new "TaskSheet" feature that allows users to select between different Pomodoro and work sessions via a bottom sheet modal. It also adds reusable UI components for displaying session tasks, session durations, and improves the app's UI infrastructure to support bottom sheets. Additionally, utility and dependency updates are included to support these features.

**New UI Features and Components:**

* Added `TaskSheet` component, which presents a bottom sheet modal for selecting between different Pomodoro and work sessions, integrating with the current Pomodoro state and providing multiple preset session options. (`components/TaskSheet.tsx`, `app/(tabs)/index.tsx`) [[1]](diffhunk://#diff-6fb109541c6989e6bd080c81f049ad7f01195607adef000d8e19de80a2698f45R1-R100) [[2]](diffhunk://#diff-f1376aabc191da604c7467683d96ee39e243cbc17a4a4caaa41d43f1979a1ebdL3-R12)
* Introduced `TaskButton` component for displaying task/session names and their durations in a visually appealing, reusable format. (`components/TaskButton.tsx`)

**UI Infrastructure and Integration:**

* Integrated `@gorhom/bottom-sheet` into the app, wrapping the root layout with `BottomSheetModalProvider` and `GestureHandlerRootView` to enable modal bottom sheets across the app. (`app/_layout.tsx`, `package.json`) [[1]](diffhunk://#diff-a297596ca5a79abd3db7509592a07106f1c27c02ee55895a4dee8bcce9f7da57L3-R22) [[2]](diffhunk://#diff-a297596ca5a79abd3db7509592a07106f1c27c02ee55895a4dee8bcce9f7da57R47-R57) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R16)
* Improved styling and layout for the home screen and root layout to accommodate the new TaskSheet and bottom sheet modal. (`app/(tabs)/index.tsx`, `app/_layout.tsx`) [[1]](diffhunk://#diff-f1376aabc191da604c7467683d96ee39e243cbc17a4a4caaa41d43f1979a1ebdL3-R12) [[2]](diffhunk://#diff-a297596ca5a79abd3db7509592a07106f1c27c02ee55895a4dee8bcce9f7da57L3-R22)

**Utility and Data Handling:**

* Added `formatDuration` utility function to format session durations for display (e.g., "1sa 30dk" for 1 hour 30 minutes). (`lib/utils.ts`)
* Updated Pomodoro hooks to export `currentPomodoro` and related types for use in the new components. (`lib/hooks/usePomodoro.ts`)

**Dependency Updates:**

* Added `@gorhom/bottom-sheet` and `@shopify/flash-list` to dependencies to support new UI features. (`package.json`) [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R16) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R25)

**Development Tooling:**

* Updated local MCP server configuration for development. (`.cursor/mcp.json`)