### PR TITLE
Added: FE: Dark Mode

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -14,7 +14,7 @@ export default function HomeScreen() {
         size={width * 0.8}
         fontSize={width}
         strokeWidth={width * 0.05}
-        initialSeconds={25 * 60}
+        initialSeconds={1 * 60}
         onComplete={() => {
           console.log("Pomodoro session completed from HomeScreen!");
         }}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,3 @@
-
-
 import "@/global.css";
 import { AppThemeProvider } from "@/lib/theme-provider";
 import {
@@ -43,14 +41,14 @@ export default function RootLayout() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <BottomSheetModalProvider>
-        <AppThemeProvider>
+      <AppThemeProvider>
+        <BottomSheetModalProvider>
           <Stack>
             <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
           </Stack>
           <PortalHost />
-        </AppThemeProvider>
-      </BottomSheetModalProvider>
+        </BottomSheetModalProvider>
+      </AppThemeProvider>
     </GestureHandlerRootView>
   );
 }

--- a/components/PomodoroTimer.tsx
+++ b/components/PomodoroTimer.tsx
@@ -9,7 +9,11 @@ import Animated from "react-native-reanimated";
 
 import CircularProgressBar from "@/components/ui/circular-progress";
 import { PomodoroButton } from "@/components/ui/pomodoro-button";
-import { LAYOUT_DIMENSIONS, POMODORO_COLORS, POMODORO_DEFAULTS } from "@/lib/constants/pomodoro";
+import {
+  LAYOUT_DIMENSIONS,
+  POMODORO_COLORS,
+  POMODORO_DEFAULTS,
+} from "@/lib/constants/pomodoro";
 import { usePomodoroAnimations } from "@/lib/hooks/usePomodoroAnimations";
 import { useTimer } from "@/lib/hooks/useTimer";
 import type { PomodoroTimerProps } from "@/lib/types/pomodoro";
@@ -19,7 +23,7 @@ import {
   getSplitButtonsConfig,
   getTimerState,
 } from "@/lib/utils/pomodoroHelpers";
-
+import { useTheme } from "@react-navigation/native";
 
 export const PomodoroTimer: React.FC<PomodoroTimerProps> = ({
   initialSeconds = POMODORO_DEFAULTS.INITIAL_SECONDS,
@@ -31,22 +35,22 @@ export const PomodoroTimer: React.FC<PomodoroTimerProps> = ({
   totalSessions = POMODORO_DEFAULTS.DEFAULT_SESSIONS,
 }) => {
   // Timer logic
-  const { 
-    timeRemaining, 
-    isRunning, 
+  const {
+    timeRemaining,
+    isRunning,
     isPaused,
-    isCompleted, 
-    progress, 
-    formattedTime, 
-    startTimer, 
-    pauseTimer, 
-    resetTimer 
-  } = useTimer({ 
+    isCompleted,
+    progress,
+    formattedTime,
+    startTimer,
+    pauseTimer,
+    resetTimer,
+  } = useTimer({
     initialSeconds,
     onComplete: () => {
       console.log("Pomodoro session completed!");
       onComplete?.();
-    }
+    },
   });
 
   // Determine current state and get animations
@@ -64,8 +68,7 @@ export const PomodoroTimer: React.FC<PomodoroTimerProps> = ({
     onResume: startTimer,
     onStop: resetTimer,
   });
-
-
+  const { dark } = useTheme();
 
   return (
     <View className="items-center gap-16 w-full">
@@ -75,21 +78,28 @@ export const PomodoroTimer: React.FC<PomodoroTimerProps> = ({
         size={size}
         strokeWidth={strokeWidth}
         color={POMODORO_COLORS.PRIMARY_GREEN}
+        backgroundColor={dark ? "#18181b" : "#e5e7eb"}
         title={formattedTime}
         subtitle={formatSessionInfo(currentSession, totalSessions)}
       />
 
-      <View 
-        className="w-full items-center justify-center" 
+      <View
+        className="w-full items-center justify-center"
         style={{ minHeight: LAYOUT_DIMENSIONS.BUTTON_CONTAINER_MIN_HEIGHT }}
       >
         {/* Main morphing button - appears for idle, running, completed states */}
-        {timerState !== 'paused' && (
-          <Animated.View 
-            style={[animations.morphingButtonStyle, { width: LAYOUT_DIMENSIONS.MAIN_BUTTON_WIDTH, position: 'absolute' }]}
+        {timerState !== "paused" && (
+          <Animated.View
+            style={[
+              animations.morphingButtonStyle,
+              {
+                width: LAYOUT_DIMENSIONS.MAIN_BUTTON_WIDTH,
+                position: "absolute",
+              },
+            ]}
             className="rounded-full"
           >
-            <PomodoroButton 
+            <PomodoroButton
               config={mainButtonConfig}
               className="w-full bg-transparent border-transparent"
             />
@@ -97,17 +107,17 @@ export const PomodoroTimer: React.FC<PomodoroTimerProps> = ({
         )}
 
         {/* Split buttons container - appears when paused */}
-        {timerState === 'paused' && (
-          <Animated.View 
-            style={[animations.splitContainerStyle, { width: LAYOUT_DIMENSIONS.SPLIT_CONTAINER_WIDTH }]}
+        {timerState === "paused" && (
+          <Animated.View
+            style={[
+              animations.splitContainerStyle,
+              { width: LAYOUT_DIMENSIONS.SPLIT_CONTAINER_WIDTH },
+            ]}
             className="flex-row gap-3 items-center justify-center"
           >
             {/* Resume button (left) */}
-            <Animated.View 
-              style={animations.leftSplitStyle}
-              className="flex-1"
-            >
-              <PomodoroButton 
+            <Animated.View style={animations.leftSplitStyle} className="flex-1">
+              <PomodoroButton
                 config={splitButtonsConfig.left}
                 className="px-2"
                 textSize="text-lg"
@@ -115,11 +125,11 @@ export const PomodoroTimer: React.FC<PomodoroTimerProps> = ({
             </Animated.View>
 
             {/* Stop button (right) */}
-            <Animated.View 
+            <Animated.View
               style={animations.rightSplitStyle}
               className="flex-1"
             >
-              <PomodoroButton 
+              <PomodoroButton
                 config={splitButtonsConfig.right}
                 className="px-2"
                 textSize="text-lg"

--- a/components/TaskButton.tsx
+++ b/components/TaskButton.tsx
@@ -27,7 +27,7 @@ export const TaskButton: React.FC<TaskButtonProps> = ({
   const renderSessionDurations = () => {
     return sessions.sort((a, b) => a.step - b.step).map((session, index) => (
       <View key={session.id} className="flex-row items-center">
-        <Text className="text-xs text-gray-600">
+        <Text className="text-xs text-muted-foreground">
           {formatDuration(session.total_seconds)}
         </Text>
         {index < sessions.length - 1 && (
@@ -42,7 +42,7 @@ export const TaskButton: React.FC<TaskButtonProps> = ({
   return (
     <TouchableOpacity
       onPress={onPress}
-      className="bg-white rounded-3xl p-4 mb-3 border border-zinc-200"
+      className="bg-primary-foreground rounded-3xl p-4 mb-3 border border-border"
       style={{
         borderLeftWidth: 4,
         borderLeftColor: borderColor,
@@ -50,7 +50,7 @@ export const TaskButton: React.FC<TaskButtonProps> = ({
     >
       {/* Title Row */}
       <View className="mb-2">
-        <Text className="text-lg font-sans-medium text-gray-900">{title}</Text>
+        <Text className="text-lg font-sans-medium text-foreground">{title}</Text>
       </View>
       
       {/* Session Info Row */}

--- a/components/TaskSheet.tsx
+++ b/components/TaskSheet.tsx
@@ -1,5 +1,6 @@
 import { Text } from "@/components/ui/text";
 import { currentPomodoro } from "@/lib/hooks/usePomodoro";
+import { THEME } from "@/lib/theme";
 import {
   BottomSheetBackdrop,
   BottomSheetModal,
@@ -73,8 +74,14 @@ const TaskSheet = () => {
           overflow: "hidden",
           borderRadius: BORDER_RADIUS,
         }}
+        handleStyle={{
+          backgroundColor: dark ? THEME.dark.primaryForeground : THEME.light.primaryForeground,
+          borderTopLeftRadius: BORDER_RADIUS,
+          borderTopRightRadius: BORDER_RADIUS,
+        
+        }}
         handleIndicatorStyle={{
-          backgroundColor: "#D1D5DB",
+          backgroundColor: dark ? THEME.dark.secondary : THEME.light.secondaryForeground,
           width: 50,
         }}
         backdropComponent={(props) => (
@@ -87,7 +94,7 @@ const TaskSheet = () => {
         )}
       >
         <BottomSheetView
-          className="flex-1 px-5"
+          className="flex-1 px-5 bg-primary-foreground"
           style={{
             paddingBottom: Platform.select({
               ios: insets.bottom + 12,
@@ -95,7 +102,7 @@ const TaskSheet = () => {
             }),
           }}
         >
-          <Text className="text-xl font-sans-semibold text-gray-900 mb-4">
+          <Text className="text-xl font-sans-semibold text-foreground mb-4">
             Select Pomodoro Session
           </Text>
 

--- a/components/ui/circular-progress.tsx
+++ b/components/ui/circular-progress.tsx
@@ -102,12 +102,12 @@ const CircularProgressBar: React.FC<CircularProgressBarProps> = ({
           }}
         >
           <Text
-            className="font-sans-bold text-zinc-900 text-6xl"
+            className="font-sans-bold  text-6xl"
            
           >
             {title}
           </Text>
-          <Text className="font-sans-semibold text-zinc-400">{subtitle}</Text>
+          <Text className="font-sans-semibold text-muted-foreground">{subtitle}</Text>
         </View>
       )}
     </View>


### PR DESCRIPTION
This pull request focuses on improving theming consistency across the app, especially for dark mode support, and refines the Pomodoro timer UI and logic. The most significant changes include updating color and style references to use theme variables, enhancing the Pomodoro timer's configurability and appearance, and cleaning up code formatting and structure.

**Theming and Style Consistency:**

- Updated various components (e.g., `TaskButton`, `TaskSheet`, `CircularProgressBar`) to use theme-based color classes and variables (`text-foreground`, `bg-primary-foreground`, `border-border`, etc.) instead of hardcoded colors, ensuring proper dark mode support and consistent styling. [[1]](diffhunk://#diff-9c6634967ede7ea4bc678b890a136e92866f858a8a12c1fee0b37572759c8e37L30-R30) [[2]](diffhunk://#diff-9c6634967ede7ea4bc678b890a136e92866f858a8a12c1fee0b37572759c8e37L45-R53) [[3]](diffhunk://#diff-6fb109541c6989e6bd080c81f049ad7f01195607adef000d8e19de80a2698f45R77-R84) [[4]](diffhunk://#diff-6fb109541c6989e6bd080c81f049ad7f01195607adef000d8e19de80a2698f45L90-R105) [[5]](diffhunk://#diff-6c9ca64b1d43001ce1684708d6c1ac9e2e74bba761bc382797f698a885584fa3L105-R110)

**Pomodoro Timer Improvements:**

- Added dynamic background color to the `CircularProgressBar` in the Pomodoro timer based on the current theme, and improved prop formatting and code readability. [[1]](diffhunk://#diff-1a29e488f8a1680548c13f6440badaa5148b4645bfd45dcf2828c6c9f0780976L67-R71) [[2]](diffhunk://#diff-1a29e488f8a1680548c13f6440badaa5148b4645bfd45dcf2828c6c9f0780976R81) [[3]](diffhunk://#diff-1a29e488f8a1680548c13f6440badaa5148b4645bfd45dcf2828c6c9f0780976L87-R99) [[4]](diffhunk://#diff-1a29e488f8a1680548c13f6440badaa5148b4645bfd45dcf2828c6c9f0780976L100-R119)
- Changed the default Pomodoro session duration in `HomeScreen` from 25 minutes to 1 minute for testing or demonstration purposes.

**Code Structure and Formatting:**

- Improved import formatting and added missing imports (e.g., `useTheme` from `@react-navigation/native`) to support new theming logic. [[1]](diffhunk://#diff-1a29e488f8a1680548c13f6440badaa5148b4645bfd45dcf2828c6c9f0780976L12-R16) [[2]](diffhunk://#diff-1a29e488f8a1680548c13f6440badaa5148b4645bfd45dcf2828c6c9f0780976L22-R26) [[3]](diffhunk://#diff-6fb109541c6989e6bd080c81f049ad7f01195607adef000d8e19de80a2698f45R3)
- Cleaned up and reordered context providers in the app layout to ensure correct provider hierarchy.

These changes collectively enhance the user experience by making the app visually cohesive across light and dark themes, improving maintainability, and refining the Pomodoro timer's usability.